### PR TITLE
feat: add disease detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
+import Disease from './pages/Disease'
 import Container from './components/Container'
 
 export default function App() {
@@ -7,6 +8,7 @@ export default function App() {
     <Container>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/disease/:slug" element={<Disease />} />
       </Routes>
     </Container>
   )

--- a/src/pages/Disease.tsx
+++ b/src/pages/Disease.tsx
@@ -1,0 +1,56 @@
+import { useParams, Link } from 'react-router-dom'
+import { getDiseaseBySlug } from '../data/diseases'
+
+function renderList(title: string, items?: string[]) {
+  if (!items || items.length === 0) return null
+  return (
+    <section className="mb-4">
+      <h2 className="font-semibold">{title}</h2>
+      <ul className="list-disc pl-4">
+        {items.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default function Disease() {
+  const { slug } = useParams<{ slug: string }>()
+  const disease = slug ? getDiseaseBySlug(slug) : undefined
+
+  if (!disease) {
+    return (
+      <div>
+        <h1 className="mb-4 text-xl font-semibold">404</h1>
+        <p>Penyakit tidak ditemukan.</p>
+        <Link to="/" className="text-blue-600 underline">
+          Kembali ke beranda
+        </Link>
+      </div>
+    )
+  }
+
+  const s = disease.sections
+
+  return (
+    <article>
+      <h1 className="mb-4 text-xl font-semibold">{disease.name}</h1>
+      {s?.header && <p className="mb-4">{s.header}</p>}
+      {s?.apaItu && (
+        <section className="mb-4">
+          <h2 className="font-semibold">Apa itu?</h2>
+          <p>{s.apaItu}</p>
+        </section>
+      )}
+      {renderList('Faktor Risiko', s?.faktorRisiko)}
+      {renderList('Gejala', s?.gejala)}
+      {renderList('Tanda Bahaya', s?.tandaBahaya)}
+      {renderList('Pemeriksaan', s?.pemeriksaan)}
+      {renderList('Penanganan', s?.penanganan)}
+      {renderList('Checklist', s?.checklist)}
+      {renderList('FAQ', s?.faq)}
+    </article>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add Disease page that renders disease sections or shows a friendly 404
- wire up `/disease/:slug` route

## Testing
- `npx --yes vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b5a1a392f4832a9d0eeba18f81c243