### PR TITLE
feat: add quiz component and disease integration

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+
+export interface QuizQuestion {
+  question: string
+  options: string[]
+  answer: number
+}
+
+interface QuizProps {
+  questions: QuizQuestion[]
+  onFinish: (score: number) => void
+}
+
+export default function Quiz({ questions, onFinish }: QuizProps) {
+  const [current, setCurrent] = useState(0)
+  const [selected, setSelected] = useState<number[]>(
+    Array(questions.length).fill(-1)
+  )
+  const [finished, setFinished] = useState(false)
+  const [score, setScore] = useState(0)
+
+  const q = questions[current]
+
+  function selectOption(index: number) {
+    const next = [...selected]
+    next[current] = index
+    setSelected(next)
+  }
+
+  function nextQuestion() {
+    if (current < questions.length - 1) {
+      setCurrent((c) => c + 1)
+    } else {
+      const s = selected.reduce(
+        (acc, val, i) => acc + (val === questions[i].answer ? 1 : 0),
+        0
+      )
+      setScore(s)
+      setFinished(true)
+      onFinish(s)
+    }
+  }
+
+  if (finished) {
+    return (
+      <div className="mt-2">
+        Skor Anda: {score}/{questions.length}
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-2">
+      <p className="mb-2">
+        {current + 1}. {q.question}
+      </p>
+      <ul className="mb-2">
+        {q.options.map((opt, i) => (
+          <li key={i} className="mb-1">
+            <label className="flex items-center gap-2">
+              <input
+                type="radio"
+                name={`q-${current}`}
+                checked={selected[current] === i}
+                onChange={() => selectOption(i)}
+              />
+              {opt}
+            </label>
+          </li>
+        ))}
+      </ul>
+      <button
+        disabled={selected[current] === -1}
+        onClick={nextQuestion}
+        className="rounded bg-blue-600 px-3 py-1 text-white disabled:opacity-50"
+      >
+        {current === questions.length - 1 ? 'Selesai' : 'Lanjut'}
+      </button>
+    </div>
+  )
+}
+

--- a/src/data/diseases.ts
+++ b/src/data/diseases.ts
@@ -14,6 +14,11 @@ export interface Disease {
     checklist?: string[];
     faq?: string[];
   };
+  quiz?: {
+    question: string;
+    options: string[];
+    answer: number;
+  }[];
 }
 
 export const diseases: Disease[] = [
@@ -128,6 +133,33 @@ export const diseases: Disease[] = [
         '"Kapan ke UGD?" → Saat muncul tanda bahaya.',
       ],
     },
+    quiz: [
+      {
+        question: 'Berapa batas tekanan darah untuk diagnosis hipertensi?',
+        options: ['≥140/90 mmHg', '≥120/80 mmHg', '≥160/100 mmHg', '≥100/70 mmHg'],
+        answer: 0,
+      },
+      {
+        question: 'Faktor risiko utama hipertensi berikut adalah?',
+        options: ['Konsumsi garam tinggi', 'Olahraga teratur', 'Berat badan ideal', 'Tidur cukup'],
+        answer: 0,
+      },
+      {
+        question: 'Tanda bahaya hipertensi yang memerlukan UGD adalah?',
+        options: ['Nyeri dada', 'Pusing ringan', 'Keringat dingin', 'Kaki bengkak'],
+        answer: 0,
+      },
+      {
+        question: 'Batas konsumsi garam per hari untuk penderita hipertensi?',
+        options: ['<2 gram natrium', '<5 gram natrium', '<10 gram natrium', '<1 gram natrium'],
+        answer: 0,
+      },
+      {
+        question: 'Durasi olahraga aerobik yang dianjurkan per minggu?',
+        options: ['150 menit', '60 menit', '300 menit', '30 menit'],
+        answer: 0,
+      },
+    ],
   },
   {
     slug: 'isk',

--- a/src/pages/Disease.tsx
+++ b/src/pages/Disease.tsx
@@ -1,5 +1,6 @@
 import { useParams, Link } from 'react-router-dom'
 import { getDiseaseBySlug } from '../data/diseases'
+import Quiz from '../components/Quiz'
 
 function renderList(title: string, items?: string[]) {
   if (!items || items.length === 0) return null
@@ -50,6 +51,17 @@ export default function Disease() {
       {renderList('Penanganan', s?.penanganan)}
       {renderList('Checklist', s?.checklist)}
       {renderList('FAQ', s?.faq)}
+      {disease.quiz && (
+        <details className="mb-4">
+          <summary className="cursor-pointer font-semibold">Kuis</summary>
+          <Quiz
+            questions={disease.quiz}
+            onFinish={(score) =>
+              localStorage.setItem(`quiz:zmc:${disease.slug}`, String(score))
+            }
+          />
+        </details>
+      )}
     </article>
   )
 }


### PR DESCRIPTION
## Summary
- add Quiz component to run disease questions and calculate score
- integrate Quiz in disease page with accordion tab and localStorage score
- provide sample five hypertension questions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5a2be7128832aa886abf3eb57884d