### PR TITLE
feat: enable offline support

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Offline</title>
+    <style>
+      body { font-family: sans-serif; padding: 1rem; text-align: center; }
+    </style>
+  </head>
+  <body>
+    <h1>Anda sedang offline</h1>
+    <p>Silakan periksa koneksi internet Anda.</p>
+  </body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { registerSW } from 'virtual:pwa-register'
 import App from './App'
 import './index.css'
+
+registerSW()
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,26 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
+      includeAssets: ['offline.html'],
+      workbox: {
+        navigateFallback: '/offline.html',
+        runtimeCaching: [
+          {
+            urlPattern: ({ url }) => url.pathname === '/',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'home-cache'
+            }
+          },
+          {
+            urlPattern: ({ url }) => url.pathname.startsWith('/disease'),
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'disease-cache'
+            }
+          }
+        ]
+      },
       manifest: {
         name: 'ZMC Edukasi',
         short_name: 'ZMC Edukasi',


### PR DESCRIPTION
## Summary
- configure VitePWA to cache home and disease routes and serve an offline fallback
- register service worker
- add static offline page

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5a4db99e0832a9f8554472d463449