### PR TITLE
feat: add basic analytics tracking

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { track } from '../utils/analytics'
 
 export interface QuizQuestion {
   question: string
@@ -19,6 +20,10 @@ export default function Quiz({ questions, onFinish }: QuizProps) {
   const [finished, setFinished] = useState(false)
   const [score, setScore] = useState(0)
 
+  useEffect(() => {
+    track('quiz_start', { total: questions.length })
+  }, [questions.length])
+
   const q = questions[current]
 
   function selectOption(index: number) {
@@ -37,6 +42,7 @@ export default function Quiz({ questions, onFinish }: QuizProps) {
       )
       setScore(s)
       setFinished(true)
+      track('quiz_finish', { score: s, total: questions.length })
       onFinish(s)
     }
   }

--- a/src/pages/Disease.tsx
+++ b/src/pages/Disease.tsx
@@ -1,7 +1,9 @@
+import { useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { getDiseaseBySlug } from '../data/diseases'
 import Quiz from '../components/Quiz'
 import { generateLeafletPDF } from '../utils/leaflet'
+import { track } from '../utils/analytics'
 
 function renderList(title: string, items?: string[]) {
   if (!items || items.length === 0) return null
@@ -20,6 +22,12 @@ function renderList(title: string, items?: string[]) {
 export default function Disease() {
   const { slug } = useParams<{ slug: string }>()
   const disease = slug ? getDiseaseBySlug(slug) : undefined
+
+  useEffect(() => {
+    if (disease) {
+      track('disease_view', { slug: disease.slug })
+    }
+  }, [disease])
 
   if (!disease) {
     return (
@@ -63,9 +71,9 @@ export default function Disease() {
           <summary className="cursor-pointer font-semibold">Kuis</summary>
           <Quiz
             questions={disease.quiz}
-            onFinish={(score) =>
+            onFinish={(score) => {
               localStorage.setItem(`quiz:zmc:${disease.slug}`, String(score))
-            }
+            }}
           />
         </details>
       )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,35 @@
+import { useEffect, useState } from 'react'
 import DiseaseCard from '../components/DiseaseCard'
 import { diseases } from '../data/diseases'
+import { getEvents } from '../utils/analytics'
 
 export default function Home() {
   const wave1 = diseases.filter((d) => d.wave === 1)
+  const [summary, setSummary] = useState({
+    diseaseViews: 0,
+    quizFinish: 0,
+  })
+
+  useEffect(() => {
+    const events = getEvents()
+    setSummary({
+      diseaseViews: events.filter((e) => e.name === 'disease_view').length,
+      quizFinish: events.filter((e) => e.name === 'quiz_finish').length,
+    })
+  }, [])
 
   return (
     <div>
       <h1 className="mb-4 text-xl font-semibold">Beranda</h1>
+      {(summary.diseaseViews > 0 || summary.quizFinish > 0) && (
+        <div className="mb-4">
+          <h2 className="font-semibold">Ringkasan Aktivitas</h2>
+          <ul className="list-disc pl-4">
+            <li>Halaman penyakit dikunjungi: {summary.diseaseViews} kali</li>
+            <li>Kuis diselesaikan: {summary.quizFinish} kali</li>
+          </ul>
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
         {wave1.map((disease) => (
           <DiseaseCard key={disease.slug} disease={disease} />

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,27 @@
+export interface AnalyticsEvent {
+  name: string
+  payload?: unknown
+  timestamp: number
+}
+
+const STORAGE_KEY = 'analytics:zmc'
+
+export function track(name: string, payload?: unknown) {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    const events: AnalyticsEvent[] = raw ? JSON.parse(raw) : []
+    events.push({ name, payload, timestamp: Date.now() })
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(events))
+  } catch (err) {
+    // ignore write errors
+  }
+}
+
+export function getEvents(): AnalyticsEvent[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch (err) {
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- add analytics utility to store events in localStorage
- track disease page views and quiz interactions
- show analytics summary on the home page

## Testing
- `npm test`
- `npm run build` *(fails: Rollup failed to resolve import "jspdf" from src/utils/leaflet.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b6d09970832a902b6f8ab5d6f483