### PR TITLE
docs: add Vercel deployment guide and badge

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,17 @@
+# Deployment
+
+Langkah-langkah deploy ke Vercel:
+
+1. Masuk ke [Vercel](https://vercel.com) dan pilih **New Project**.
+2. Import repository GitHub ini.
+3. Saat konfigurasi:
+   - **Build Command**: `npm run build`
+   - **Output Directory**: `dist`
+4. Klik **Deploy** dan tunggu proses selesai.
+
+Untuk verifikasi lokal sebelum deploy:
+
+```bash
+npm run build
+npm run preview
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # zmcEdukasi
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository=https://github.com/zmcEdukasi/zmcEdukasi)
+
 Aplikasi Edukasi Penyakit ZMC — Publik-Only MVP
 📖 Ringkasan
 Proyek ini adalah aplikasi edukasi kesehatan untuk publik yang dikembangkan untuk Klinik Pratama Zihan Medical Center (ZMC). Aplikasi ini berbasis PWA (Progressive Web App) dengan konsep offline-first, ditujukan bagi pasien, keluarga, dan masyarakat umum. Fokusnya adalah menyajikan informasi kesehatan yang jelas, terstruktur, dan mudah diakses — tanpa fitur klinis — untuk meningkatkan literasi, mengurangi miskonsepsi, serta mendorong perilaku hidup sehat【25†source】.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --port 4173",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- document steps to deploy on Vercel and verify build
- add Deploy with Vercel badge in README
- pin preview script to port 4173 for Vercel

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c140a69c832aabc4514946c5eaa3