### PR TITLE
feat: add i18n support and TTS hook stub

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,13 +1,18 @@
 import { Link } from 'react-router-dom'
 import { useEffect, useState } from 'react'
+import { getLabels, Lang } from '../i18n'
 
 export default function Header() {
+  const [lang, setLang] = useState<Lang>(
+    () => (localStorage.getItem('ui:lang') as Lang) || 'id'
+  )
   const [highContrast, setHighContrast] = useState(
     () => localStorage.getItem('a11y:zmc:contrast') === '1'
   )
   const [largeText, setLargeText] = useState(
     () => localStorage.getItem('a11y:zmc:font') === '1'
   )
+  const labels = getLabels(lang)
 
   useEffect(() => {
     localStorage.setItem('a11y:zmc:contrast', highContrast ? '1' : '0')
@@ -29,17 +34,21 @@ export default function Header() {
     }
   }, [largeText])
 
+  useEffect(() => {
+    localStorage.setItem('ui:lang', lang)
+  }, [lang])
+
   return (
     <header
       className={`${highContrast ? 'bg-black text-white' : 'bg-sky-700 text-white'}`}
     >
       <div className="mx-auto flex max-w-4xl items-center justify-between p-4">
         <Link to="/" className="text-base font-bold">
-          Aplikasi Edukasi Penyakit ZMC
+          {labels.appTitle}
         </Link>
         <nav className="flex items-center gap-2">
           <Link to="/" className="px-2 py-1 text-sm font-medium">
-            Beranda
+            {labels.home}
           </Link>
           <label className="text-sm">
             <input
@@ -48,7 +57,7 @@ export default function Header() {
               checked={highContrast}
               onChange={(e) => setHighContrast(e.target.checked)}
             />
-            Kontras Tinggi
+            {labels.highContrast}
           </label>
           <label className="text-sm">
             <input
@@ -57,7 +66,18 @@ export default function Header() {
               checked={largeText}
               onChange={(e) => setLargeText(e.target.checked)}
             />
-            Font Besar
+            {labels.largeText}
+          </label>
+          <label className="text-sm">
+            {labels.language}
+            <select
+              className="ml-1 text-black"
+              value={lang}
+              onChange={(e) => setLang(e.target.value as Lang)}
+            >
+              <option value="id">Indonesia</option>
+              <option value="su">Sunda</option>
+            </select>
           </label>
         </nav>
       </div>

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,0 +1,11 @@
+export function useTTS() {
+  const speak = (_text: string) => {
+    // TODO: integrate text-to-speech engine
+  }
+
+  const stop = () => {
+    // TODO: stop text-to-speech playback
+  }
+
+  return { speak, stop }
+}

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -1,0 +1,7 @@
+export default {
+  appTitle: 'Aplikasi Edukasi Penyakit ZMC',
+  home: 'Beranda',
+  highContrast: 'Kontras Tinggi',
+  largeText: 'Font Besar',
+  language: 'Bahasa',
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,9 @@
+import id from './id'
+import su from './su'
+
+export const translations = { id, su }
+export type Lang = keyof typeof translations
+
+export function getLabels(lang: Lang) {
+  return translations[lang]
+}

--- a/src/i18n/su.ts
+++ b/src/i18n/su.ts
@@ -1,0 +1,7 @@
+export default {
+  appTitle: 'Aplikasi Édukasi Panyakit ZMC',
+  home: 'Tepas',
+  highContrast: 'Kontras Luhur',
+  largeText: 'Téks Gedé',
+  language: 'Basa',
+}


### PR DESCRIPTION
## Summary
- add Indonesian and Sundanese i18n label files
- let header switch and persist UI language
- scaffold `useTTS` hook for future text-to-speech integration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c899ce9c832a9747468b3ce3453d