### PR TITLE
feat: add responsive header navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,7 @@ export default function Header() {
   const [largeText, setLargeText] = useState(
     () => localStorage.getItem('a11y:zmc:font') === '1'
   )
+  const [menuOpen, setMenuOpen] = useState(false)
   const labels = getLabels(lang)
 
   useEffect(() => {
@@ -40,17 +41,51 @@ export default function Header() {
 
   return (
     <header
-      className={`${highContrast ? 'bg-black text-white' : 'bg-brand-primary text-brand-background'}`}
+      className={`${highContrast ? 'bg-black text-white' : 'bg-brand-primary text-brand-background'} font-brand`}
     >
-      <div className="mx-auto flex max-w-4xl items-center justify-between p-4">
+      <div className="relative mx-auto flex max-w-4xl items-center justify-between p-4">
         <Link to="/" className="text-base font-bold font-heading">
           {labels.appTitle}
         </Link>
-        <nav className="flex items-center gap-2">
-          <Link to="/" className="px-2 py-1 text-sm font-medium">
+        <button
+          className="rounded p-2 hover:bg-brand-accent/20 focus:bg-brand-accent/20 focus:outline-none md:hidden"
+          onClick={() => setMenuOpen((o) => !o)}
+          aria-label="Toggle navigation"
+        >
+          <svg
+            className="h-6 w-6"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            {menuOpen ? (
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            ) : (
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M4 6h16M4 12h16M4 18h16"
+              />
+            )}
+          </svg>
+        </button>
+        <nav
+          className={`${menuOpen ? 'flex' : 'hidden'} absolute left-0 top-full w-full flex-col gap-2 bg-brand-primary px-4 pb-4 md:static md:flex md:w-auto md:flex-row md:items-center md:gap-2 md:bg-transparent md:p-0`}
+        >
+          <Link
+            to="/"
+            className="rounded px-3 py-2 text-sm font-medium hover:bg-brand-accent hover:text-brand-background focus:bg-brand-accent focus:text-brand-background"
+          >
             {labels.home}
           </Link>
-          <label className="text-sm">
+          <label className="flex items-center rounded px-3 py-2 text-sm hover:bg-brand-accent/20 focus-within:bg-brand-accent/20">
             <input
               type="checkbox"
               className="mr-1"
@@ -59,7 +94,7 @@ export default function Header() {
             />
             {labels.highContrast}
           </label>
-          <label className="text-sm">
+          <label className="flex items-center rounded px-3 py-2 text-sm hover:bg-brand-accent/20 focus-within:bg-brand-accent/20">
             <input
               type="checkbox"
               className="mr-1"
@@ -68,7 +103,7 @@ export default function Header() {
             />
             {labels.largeText}
           </label>
-          <label className="text-sm">
+          <label className="flex items-center rounded px-3 py-2 text-sm hover:bg-brand-accent/20 focus-within:bg-brand-accent/20">
             {labels.language}
             <select
               className="ml-1 text-brand-foreground"


### PR DESCRIPTION
## Summary
- replace static nav with responsive layout using hamburger toggle
- apply brand colors, fonts, and interactive styles
- keep language and accessibility controls usable on mobile

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d1530abc832aa3ded1ea902f229a