### PR TITLE
feat: polish disease cards with image slot

### DIFF
--- a/src/components/DiseaseCard.tsx
+++ b/src/components/DiseaseCard.tsx
@@ -10,10 +10,28 @@ export default function DiseaseCard({ disease }: DiseaseCardProps) {
     <Link
       to={`/disease/${disease.slug}`}
       role="link"
-      className="block rounded-2xl shadow p-4 transition hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-primary"
+      className="group block overflow-hidden rounded-2xl border border-brand-surfaceMuted bg-brand-surface shadow-sm transition-transform hover:-translate-y-1 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-brand-primary"
     >
-      <h2 className="mb-1 text-lg font-semibold">{disease.name}</h2>
-      <p className="text-sm text-brand-muted">{disease.summary}</p>
+      <div className="relative aspect-video overflow-hidden">
+        {disease.image ? (
+          <img
+            src={disease.image}
+            alt=""
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+        ) : (
+          <div
+            className="flex h-full w-full items-center justify-center bg-brand-surfaceMuted text-5xl text-brand-primary"
+            aria-hidden="true"
+          >
+            {disease.name.charAt(0)}
+          </div>
+        )}
+      </div>
+      <div className="p-4">
+        <h2 className="mb-1 text-lg font-semibold text-brand-foreground">{disease.name}</h2>
+        <p className="text-sm text-brand-muted">{disease.summary}</p>
+      </div>
     </Link>
   )
 }

--- a/src/data/diseases.ts
+++ b/src/data/diseases.ts
@@ -3,6 +3,7 @@ export interface Disease {
   name: string;
   summary: string;
   wave: number;
+  image?: string;
   sections?: {
     header?: string;
     apaItu?: string;


### PR DESCRIPTION
## Summary
- add optional `image` field to Disease type for upcoming visuals
- redesign DiseaseCard with image/icon area, rounded borders, and animated hover effects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d2be46d8832a8f9b719173f7348e