### PR TITLE
feat: add hero section and refine disease grid

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,22 +19,41 @@ export default function Home() {
   }, [])
 
   return (
-    <div>
-      <h1 className="mb-4 text-xl font-heading font-semibold">Beranda</h1>
+    <div className="space-y-8">
+      <section className="bg-brand-surface py-12 text-center">
+        <h1 className="mb-4 text-3xl font-heading font-bold">Beranda</h1>
+        <p className="mx-auto mb-6 max-w-2xl text-brand-secondary">
+          Temukan informasi ringkas mengenai berbagai penyakit umum dan cara
+          penanganannya.
+        </p>
+        <a
+          href="#disease-grid"
+          className="inline-block rounded bg-brand-primary px-6 py-3 font-heading font-semibold text-brand-background"
+        >
+          Mulai Belajar
+        </a>
+      </section>
+
       {(summary.diseaseViews > 0 || summary.quizFinish > 0) && (
-        <div className="mb-4">
+        <section className="container mx-auto px-4">
           <h2 className="font-heading font-semibold">Ringkasan Aktivitas</h2>
           <ul className="list-disc pl-4">
             <li>Halaman penyakit dikunjungi: {summary.diseaseViews} kali</li>
             <li>Kuis diselesaikan: {summary.quizFinish} kali</li>
           </ul>
-        </div>
+        </section>
       )}
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4">
-        {wave1.map((disease) => (
-          <DiseaseCard key={disease.slug} disease={disease} />
-        ))}
-      </div>
+
+      <section
+        id="disease-grid"
+        className="border-t border-brand-surfaceMuted bg-brand-background py-8"
+      >
+        <div className="container mx-auto grid grid-cols-1 gap-6 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          {wave1.map((disease) => (
+            <DiseaseCard key={disease.slug} disease={disease} />
+          ))}
+        </div>
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- introduce hero section with headline, description, and CTA button
- refine disease grid with consistent spacing, container margins, and adaptive columns
- add subtle background and divider styling to separate sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d3b3cbf0832aaf27446368d9989e