### PR TITLE
Adjust disease grid to show multiple columns

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -48,7 +48,7 @@ export default function Home() {
         id="disease-grid"
         className="border-t border-brand-surfaceMuted bg-brand-background py-8"
       >
-        <div className="container mx-auto grid grid-cols-1 gap-6 px-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+        <div className="container mx-auto grid grid-cols-2 gap-6 px-4 md:grid-cols-3 lg:grid-cols-4">
           {wave1.map((disease) => (
             <DiseaseCard key={disease.slug} disease={disease} />
           ))}


### PR DESCRIPTION
## Summary
- display disease cards in a multi-column grid with 2 columns on small screens and more on larger screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4d7ce0c832abbfa982aaa842113