### PR TITLE
fix: respect high-contrast body colors

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,9 @@
   body {
     line-height: 1.625;
     font-family: var(--font-brand);
+  }
+
+  html:not(.high-contrast) body {
     background-color: var(--color-brand-background);
     color: var(--color-brand-foreground);
   }


### PR DESCRIPTION
## Summary
- avoid overriding high-contrast colors by scoping body brand defaults

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f4e16600832a8373b682d26e4ee2