### PR TITLE
Improve header navigation focus styles

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -48,7 +48,7 @@ export default function Header() {
           {labels.appTitle}
         </Link>
         <button
-          className="rounded p-2 hover:bg-brand-accent/20 focus:bg-brand-accent/20 focus:outline-none md:hidden"
+          className="rounded p-2 hover:bg-brand-accent/20 focus:bg-brand-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent md:hidden"
           onClick={() => setMenuOpen((o) => !o)}
           aria-label="Toggle navigation"
         >


### PR DESCRIPTION
## Summary
- refine menu button focus styles with `focus-visible` outline removal and brand-colored ring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68c03b31c832aa1856ddcbd446848