### PR TITLE
Adopt local list styling for lists

### DIFF
--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -60,7 +60,7 @@ export default function Quiz({ questions, onFinish }: QuizProps) {
       <p className="mb-2">
         {current + 1}. {q.question}
       </p>
-      <ul className="mb-2">
+      <ul className="mb-2 list-disc pl-4">
         {q.options.map((opt, i) => (
           <li key={i} className="mb-1">
             <label className="flex items-center gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -90,8 +90,4 @@
     font-family: var(--font-heading);
     color: var(--color-brand-secondary);
   }
-
-  ul {
-    @apply list-disc pl-4;
-  }
 }


### PR DESCRIPTION
## Summary
- drop global `<ul>` styling from base CSS
- explicitly style quiz option lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b68cc6a050832a95cae146b80c66dd