### PR TITLE
fix: ensure install prompt overlay sits above page content

### DIFF
--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -31,7 +31,7 @@ export default function InstallPrompt() {
   if (!visible) return null
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="rounded bg-brand-background p-4 shadow">
         <p className="mb-4 text-brand-foreground">Install aplikasi ini?</p>
         <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- add high z-index to install prompt overlay to ensure it covers existing content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68f172850832a87a2d34af06a630b