### PR TITLE
Persist accessibility settings on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      const root = document.documentElement;
+      if (localStorage.getItem('a11y:zmc:contrast') === '1')
+        root.classList.add('high-contrast');
+      if (localStorage.getItem('a11y:zmc:font') === '1')
+        root.classList.add('large-text');
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,22 +17,10 @@ export default function Header() {
 
   useEffect(() => {
     localStorage.setItem('a11y:zmc:contrast', highContrast ? '1' : '0')
-    const cls = 'high-contrast'
-    if (highContrast) {
-      document.documentElement.classList.add(cls)
-    } else {
-      document.documentElement.classList.remove(cls)
-    }
   }, [highContrast])
 
   useEffect(() => {
     localStorage.setItem('a11y:zmc:font', largeText ? '1' : '0')
-    const cls = 'large-text'
-    if (largeText) {
-      document.documentElement.classList.add(cls)
-    } else {
-      document.documentElement.classList.remove(cls)
-    }
   }, [largeText])
 
   useEffect(() => {
@@ -91,7 +79,11 @@ export default function Header() {
               type="checkbox"
               className="mr-1"
               checked={highContrast}
-              onChange={(e) => setHighContrast(e.target.checked)}
+              onChange={(e) => {
+                const checked = e.target.checked
+                setHighContrast(checked)
+                document.documentElement.classList.toggle('high-contrast', checked)
+              }}
             />
             {labels.highContrast}
           </label>
@@ -100,7 +92,11 @@ export default function Header() {
               type="checkbox"
               className="mr-1"
               checked={largeText}
-              onChange={(e) => setLargeText(e.target.checked)}
+              onChange={(e) => {
+                const checked = e.target.checked
+                setLargeText(checked)
+                document.documentElement.classList.toggle('large-text', checked)
+              }}
             />
             {labels.largeText}
           </label>


### PR DESCRIPTION
## Summary
- initialize high-contrast and large-text classes from localStorage before booting React
- handle accessibility class toggles in Header during runtime only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6930ff7c4832ab098071927db6213