### PR TITLE
Use Inter font and Tailwind CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,19 +1,16 @@
 <!DOCTYPE html>
 <html lang="id">
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta charset="UTF-8" />
     <link
       rel="icon"
       type="image/svg+xml"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxOTIiIGhlaWdodD0iMTkyIiB2aWV3Qm94PSIwIDAgMTkyIDE5MiI+PHJlY3Qgd2lkdGg9IjE5MiIgaGVpZ2h0PSIxOTIiIGZpbGw9IiMwZDk0ODgiLz48L3N2Zz4="
     />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Poppins:wght@600&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>html{font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif}</style>
     <title>ZMC Edukasi</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- prioritize viewport meta tag in index head
- swap to Inter Google Font and load Tailwind CDN
- set default font-family to Inter and system fonts

## Testing
- `npm test`
- `curl -I "https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"`
- `curl -I "https://cdn.tailwindcss.com?plugins=forms"` *(403 Forbidden due to proxy, not 404)*

------
https://chatgpt.com/codex/tasks/task_e_68b697d28db4832ab561f2e232917862