### PR TITLE
Use logo in header and update home hero heading

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -38,8 +38,12 @@ export default function Header() {
       )}
     >
       <div className="relative mx-auto flex max-w-4xl items-center justify-between p-4">
-        <Link to="/" className="text-base font-bold font-heading">
-          {labels.appTitle}
+        <Link to="/" className="flex items-center" aria-label={labels.appTitle}>
+          <img
+            src="https://i.imgur.com/k7206jf.png"
+            alt={labels.appTitle}
+            className="h-8"
+          />
         </Link>
         <button
           className="rounded p-2 hover:bg-brand-accent/20 focus:bg-brand-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent md:hidden"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import DiseaseCard from '../components/DiseaseCard'
 import Section from '../components/Section'
 import { diseases } from '../data/diseases'
 import { getEvents } from '../utils/analytics'
+import { getLabels, Lang } from '../i18n'
 
 export default function Home() {
   const wave1 = diseases.filter((d) => d.wave === 1)
@@ -28,12 +29,13 @@ export default function Home() {
   })
 
   const letters = ['', ...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')]
+  const labels = getLabels((localStorage.getItem('ui:lang') as Lang) || 'id')
 
   return (
     <div>
-      <div className="bg-gradient-to-br from-teal-500 to-emerald-600 text-white rounded-3xl p-6 md:p-8 shadow-xl">
+      <div className="bg-gradient-to-br from-teal-500 to-emerald-600 text-white rounded-3xl p-6 md:p-8 shadow-xl select-none">
         <div className="mx-auto max-w-4xl text-center">
-          <h1 className="mb-4 text-3xl font-heading font-bold">Beranda</h1>
+          <h1 className="mb-4 text-3xl font-heading font-bold">{labels.appTitle}</h1>
           <p className="mx-auto mb-6 max-w-2xl">
             Temukan informasi ringkas mengenai berbagai penyakit umum dan cara
             penanganannya.


### PR DESCRIPTION
## Summary
- Replace text title in header with requested logo image
- Use app title in home hero and disable hero text selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd947994832ab899bb6e5b697301