### PR TITLE
feat: add blog style posts pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
 import Disease from './pages/Disease'
+import Posts from './pages/Posts'
+import Post from './pages/Post'
 import Container from './components/Container'
 
 export default function App() {
@@ -9,6 +11,8 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/disease/:slug" element={<Disease />} />
+        <Route path="/posts" element={<Posts />} />
+        <Route path="/posts/:slug" element={<Post />} />
       </Routes>
     </Container>
   )

--- a/src/data/posts.test.ts
+++ b/src/data/posts.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { posts, getPostBySlug } from './posts'
+
+describe('posts data', () => {
+  it('includes selamat datang post', () => {
+    const result = getPostBySlug('selamat-datang')
+    expect(result?.title).toBe('Selamat Datang')
+  })
+
+  it('has at least one entry', () => {
+    expect(posts.length).toBeGreaterThan(0)
+  })
+})

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -1,0 +1,22 @@
+// Tambahkan objek baru ke array `posts` untuk membuat posting baru.
+// Setiap posting membutuhkan `slug`, `title`, `summary`, dan `content`.
+export interface Post {
+  slug: string
+  title: string
+  summary: string
+  content: string
+}
+
+export const posts: Post[] = [
+  {
+    slug: 'selamat-datang',
+    title: 'Selamat Datang',
+    summary: 'Perkenalan singkat mengenai ZMC Edukasi.',
+    content:
+      'Ini adalah posting perdana di ZMC Edukasi yang mengenalkan konten seputar kesehatan.',
+  },
+]
+
+export function getPostBySlug(slug: string) {
+  return posts.find((p) => p.slug === slug)
+}

--- a/src/pages/Disease.tsx
+++ b/src/pages/Disease.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { getDiseaseBySlug } from '../data/diseases'
 import Quiz from '../components/Quiz'
@@ -61,7 +61,7 @@ export default function Disease() {
         />
       ),
     },
-  ].filter(Boolean) as { key: string; label: string; content: JSX.Element | null }[]
+  ].filter(Boolean) as { key: string; label: string; content: ReactNode }[]
 
   useEffect(() => {
     if (tab === '' && tabs.length > 0) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import DiseaseCard from '../components/DiseaseCard'
 import Section from '../components/Section'
 import { diseases } from '../data/diseases'
@@ -54,6 +55,12 @@ export default function Home() {
               >
                 Tanda Bahaya
               </a>
+              <Link
+                to="/posts"
+                className="rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
+              >
+                Posting
+              </Link>
             </div>
           </div>
           <div className="mt-6 md:mt-0">

--- a/src/pages/Post.tsx
+++ b/src/pages/Post.tsx
@@ -1,0 +1,26 @@
+import { useParams, Link } from 'react-router-dom'
+import { posts } from '../data/posts'
+
+export default function Post() {
+  const { slug } = useParams<{ slug: string }>()
+  const post = posts.find((p) => p.slug === slug)
+
+  if (!post) {
+    return (
+      <div>
+        <h1 className="mb-4 text-xl font-heading font-semibold">404</h1>
+        <p>Posting tidak ditemukan.</p>
+        <Link to="/posts" className="text-brand-primary underline">
+          Kembali ke daftar
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <article className="space-y-4">
+      <h1 className="text-3xl font-heading font-bold">{post.title}</h1>
+      <p>{post.content}</p>
+    </article>
+  )
+}

--- a/src/pages/Posts.tsx
+++ b/src/pages/Posts.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom'
+import { posts } from '../data/posts'
+
+export default function Posts() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-heading font-bold">Posting</h1>
+      <ul className="space-y-2">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link
+              to={`/posts/${post.slug}`}
+              className="text-brand-primary underline"
+            >
+              {post.title}
+            </Link>
+            <p className="text-sm text-brand-muted">{post.summary}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/utils/leaflet.ts
+++ b/src/utils/leaflet.ts
@@ -32,12 +32,12 @@ export function generateLeafletPDF(disease: Disease) {
       // ensure the whole section fits on the current page
       ensureSpace(lines.length + 1)
 
-      doc.setFont(undefined, 'bold')
+      doc.setFont('helvetica', 'bold')
       doc.text(title, 10, y)
-      doc.setFont(undefined, 'normal')
+      doc.setFont('helvetica', 'normal')
       y += lineHeight
 
-      lines.forEach((line) => {
+      lines.forEach((line: string) => {
         ensureSpace()
         if (Array.isArray(content)) {
           doc.text(`- ${line}`, 12, y)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite-plugin-pwa/client"]
   },
-  "include": ["src"]
+  "include": ["src", "vitest.setup.ts"]
 }

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,1 @@
-import { expect } from 'vitest'
-import * as matchers from '@testing-library/jest-dom/matchers'
-
-expect.extend(matchers)
+import '@testing-library/jest-dom/vitest'


### PR DESCRIPTION
## Summary
- add posts data with example entry
- show posts list and detail pages
- link posts from home hero and register routes
- declare vite and pwa virtual module types
- fix TypeScript errors and ensure tsc passes

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b7bfd29f84832aae78cc1495d38b42