### PR TITLE
Improve home navigation and activity summary

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,6 +88,13 @@ export default function Header() {
           >
             {labels.home}
           </Link>
+          <Link
+            to="/posts"
+            className="rounded px-3 py-2 text-sm font-medium hover:bg-brand-accent hover:text-brand-background focus:bg-brand-accent focus:text-brand-background"
+            onClick={() => setMenuOpen(false)}
+          >
+            {labels.posts}
+          </Link>
           <label className="flex items-center rounded px-3 py-2 text-sm hover:bg-brand-accent/20 focus-within:bg-brand-accent/20">
             <input
               type="checkbox"

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -1,7 +1,9 @@
 export default {
   appTitle: 'Aplikasi Edukasi Penyakit ZMC',
+  appDescription: 'Pelajari penyakit sehari-hari, pencegahannya, dan penanganannya.',
   home: 'Beranda',
   highContrast: 'Kontras Tinggi',
   largeText: 'Font Besar',
   language: 'Bahasa',
+  posts: 'Postingan',
 }

--- a/src/i18n/su.ts
+++ b/src/i18n/su.ts
@@ -1,7 +1,9 @@
 export default {
   appTitle: 'Aplikasi Édukasi Panyakit ZMC',
+  appDescription: 'Palajari panyakit sapopoe, pencegahanana, jeung panangananana.',
   home: 'Tepas',
   highContrast: 'Kontras Luhur',
   largeText: 'Téks Gedé',
   language: 'Basa',
+  posts: 'Tulisan',
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -39,15 +39,14 @@ export default function Home() {
           <div>
             <h1 className="mb-4 text-3xl font-heading font-bold">{labels.appTitle}</h1>
             <p className="mx-auto mb-6 max-w-2xl md:mx-0">
-              Temukan informasi ringkas mengenai berbagai penyakit umum dan cara
-              penanganannya.
+              {labels.appDescription}
             </p>
             <div className="flex justify-center gap-3 md:justify-start">
               <a
                 href="#disease-grid"
                 className="rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
               >
-                Mulai Belajar
+                Penyakit
               </a>
               <a
                 href="#danger"
@@ -63,18 +62,18 @@ export default function Home() {
               </Link>
             </div>
           </div>
-          <div className="mt-6 md:mt-0">
-            <h2 className="mb-4 text-xl font-heading font-semibold text-center md:text-left">
+          <div className="mt-6 md:mt-0 md:ml-auto md:max-w-xs">
+            <h2 className="mb-2 text-lg font-heading font-semibold text-center md:text-left">
               Ringkasan Aktivitas
             </h2>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="rounded-lg bg-brand-background p-4 text-center text-brand-foreground">
-                <p className="text-2xl font-bold">{summary.diseaseViews}</p>
-                <p className="text-sm">Modul dibuka</p>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div className="rounded-lg bg-brand-background p-2 text-center text-brand-foreground">
+                <p className="text-xl font-bold">{summary.diseaseViews}</p>
+                <p>Modul dibuka</p>
               </div>
-              <div className="rounded-lg bg-brand-background p-4 text-center text-brand-foreground">
-                <p className="text-2xl font-bold">{summary.quizFinish}</p>
-                <p className="text-sm">Kuis diisi</p>
+              <div className="rounded-lg bg-brand-background p-2 text-center text-brand-foreground">
+                <p className="text-xl font-bold">{summary.quizFinish}</p>
+                <p>Kuis diisi</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- rename "Mulai Belajar" button to "Penyakit" and add intro copy
- add Postingan link in header
- compress activity summary styling
- ensure intro description shows via translations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c559202c832a9415d5ced259c19a