### PR TITLE
Add i18n for home page description

### DIFF
--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -1,5 +1,6 @@
 export default {
   appTitle: 'Aplikasi Edukasi Penyakit ZMC',
+  appDescription: 'Pelajari penyakit sehari-hari, pencegahannya, dan penanganannya.',
   home: 'Beranda',
   highContrast: 'Kontras Tinggi',
   largeText: 'Font Besar',

--- a/src/i18n/su.ts
+++ b/src/i18n/su.ts
@@ -1,5 +1,6 @@
 export default {
   appTitle: 'Aplikasi Édukasi Panyakit ZMC',
+  appDescription: 'Diajar panyakit sapopoé, panyegahanna, jeung panangananna.',
   home: 'Tepas',
   highContrast: 'Kontras Luhur',
   largeText: 'Téks Gedé',

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -24,6 +24,12 @@ describe('Home page', () => {
       </MemoryRouter>
     )
 
+    expect(
+      screen.getByText(
+        'Pelajari penyakit sehari-hari, pencegahannya, dan penanganannya.'
+      )
+    ).toBeInTheDocument()
+
     const summaryHeading = await screen.findByRole('heading', {
       name: 'Ringkasan Aktivitas',
     })

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -39,7 +39,7 @@ export default function Home() {
           <div>
             <h1 className="mb-4 text-3xl font-heading font-bold">{labels.appTitle}</h1>
             <p className="mx-auto mb-6 max-w-2xl md:mx-0">
-              Pelajari penyakit sehari-hari, pencegahannya, dan penanganannya.
+              {labels.appDescription}
             </p>
             <div className="flex justify-center gap-3 md:justify-start">
               <a


### PR DESCRIPTION
## Summary
- Make home page description translatable and render using localized label
- Add Indonesian and Sundanese translations for new description label
- Verify home page description renders in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1ed52650832a86ed02d345bbdaa9