### PR TITLE
Fix hero layout and Instagram link style

### DIFF
--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -1,7 +1,10 @@
 export default {
   appTitle: 'Zihan Medical Center',
-  appDescription:
-    '#ZMCGakNyuekinKamu\n-- Sejak 2013--\nTANPA LIBUR\nMenerima BPJS Rawat Inap / Rawat Jalan\nWanaraja, Garut',
+  appDescription: `#ZMCGakNyuekinKamu
+-- Sejak 2013--
+TANPA LIBUR
+Menerima BPJS Rawat Inap / Rawat Jalan
+Wanaraja, Garut`,
   home: 'Beranda',
   highContrast: 'Kontras Tinggi',
   largeText: 'Font Besar',

--- a/src/i18n/id.ts
+++ b/src/i18n/id.ts
@@ -2,9 +2,9 @@ export default {
   appTitle: 'Zihan Medical Center',
   appDescription: `#ZMCGakNyuekinKamu
 -- Sejak 2013--
-TANPA LIBUR
-Menerima BPJS Rawat Inap / Rawat Jalan
-Wanaraja, Garut`,
+• TANPA LIBUR
+• Menerima BPJS Rawat Inap / Rawat Jalan
+Wanaraja, Garut.`,
   home: 'Beranda',
   highContrast: 'Kontras Tinggi',
   largeText: 'Font Besar',

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -5,5 +5,5 @@ export const translations = { id, su }
 export type Lang = keyof typeof translations
 
 export function getLabels(lang: Lang) {
-  return translations[lang]
+  return translations[lang] ?? translations.id
 }

--- a/src/i18n/su.ts
+++ b/src/i18n/su.ts
@@ -1,10 +1,10 @@
 export default {
   appTitle: 'Zihan Medical Center',
   appDescription: `#ZMCGakNyuekinKamu
--- Sejak 2013--
-TANPA LIBUR
-Menerima BPJS Rawat Inap / Rawat Jalan
-Wanaraja, Garut`,
+-- Ti saprak 2013--
+• Tanpa Libur
+• Nampi BPJS Rawat Inap / Rawat Jalan
+Wanaraja, Garut.`,
   home: 'Tepas',
   highContrast: 'Kontras Luhur',
   largeText: 'Téks Gedé',

--- a/src/i18n/su.ts
+++ b/src/i18n/su.ts
@@ -1,7 +1,10 @@
 export default {
   appTitle: 'Zihan Medical Center',
-  appDescription:
-    '#ZMCGakNyuekinKamu\n-- Sejak 2013--\nTANPA LIBUR\nMenerima BPJS Rawat Inap / Rawat Jalan\nWanaraja, Garut',
+  appDescription: `#ZMCGakNyuekinKamu
+-- Sejak 2013--
+TANPA LIBUR
+Menerima BPJS Rawat Inap / Rawat Jalan
+Wanaraja, Garut`,
   home: 'Tepas',
   highContrast: 'Kontras Luhur',
   largeText: 'Téks Gedé',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,13 +6,13 @@ import { getLabels, Lang } from '../i18n'
 
 export default function Home() {
   const labels = getLabels((localStorage.getItem('ui:lang') as Lang) || 'id')
-  const lines = (labels.appDescription ?? '').split(/\r?\n/).filter(Boolean)
+  const lines = (labels.appDescription || '').split(/\r?\n/).filter(Boolean)
 
   return (
     <div>
       <div className="bg-gradient-to-br from-teal-500 to-emerald-600 text-white rounded-3xl p-6 md:p-8 shadow-xl select-none">
-        <div className="mx-auto max-w-4xl text-center md:grid md:grid-cols-2 md:items-center md:gap-8 md:text-left">
-          <div>
+        <div className="mx-auto max-w-4xl text-center md:flex md:items-center md:gap-8 md:text-left">
+          <div className="md:w-1/2">
             <h1 className="mb-4 text-3xl font-heading font-bold">{labels.appTitle}</h1>
             <div className="mx-auto mb-6 max-w-2xl md:mx-0">
               {lines.map((line, i) => (
@@ -32,16 +32,16 @@ export default function Home() {
                 href="https://instagram.com/zihanmedicalcenter"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center rounded-lg px-3 py-2 font-medium shadow hover:shadow-md focus:outline-none focus:ring"
+                className="rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
               >
-                Instagram @zihanmedicalcenter
+                Instagram
               </a>
             </div>
           </div>
           <img
             src="https://i.imgur.com/MVolGHQ.jpeg"
             alt="Zihan Medical Center"
-            className="mx-auto mt-8 w-full rounded-2xl shadow-lg md:mt-0"
+            className="mx-auto mt-8 w-full max-w-md rounded-2xl shadow-lg md:mt-0 md:w-1/2"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- style Instagram link like diseases button for consistency
- tidy hero layout and constrain hero image
- fallback to default language so description always displays

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be44385aa0832ab366944b8a148e3e