### PR TITLE
Fix hero text visibility in contrast mode

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,7 +10,7 @@ export default function Home() {
 
   return (
     <div>
-      <div className="bg-gradient-to-br from-teal-500 to-emerald-600 text-white rounded-3xl p-6 md:p-8 shadow-xl select-none">
+      <div className="bg-gradient-to-br from-brand-primary to-brand-accent text-brand-background rounded-3xl p-6 md:p-8 shadow-xl select-none">
         <div className="mx-auto max-w-4xl text-center md:flex md:items-center md:gap-8 md:text-left">
           <div className="md:w-1/2">
             <h1 className="mb-4 text-3xl font-heading font-bold">{labels.appTitle}</h1>


### PR DESCRIPTION
## Summary
- use brand color tokens for home page hero so tagline text remains visible in all themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf7962a970832ab1b937e2b84cec3f