### PR TITLE
Ensure home CTA buttons remain visible in high-contrast mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,12 @@
     --tw-gradient-to: #000;
   }
 
+  html.high-contrast .cta-link {
+    background-color: #fff;
+    color: #000;
+    border: 1px solid #fff;
+  }
+
   html.large-text {
     font-size: 125%;
   }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -24,7 +24,7 @@ export default function Home() {
             <div className="flex justify-center gap-3 md:justify-start">
               <Link
                 to="/diseases"
-                className="rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
+                className="cta-link rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
               >
                 Penyakit
               </Link>
@@ -32,7 +32,7 @@ export default function Home() {
                 href="https://instagram.com/zihanmedicalcenter"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
+                className="cta-link rounded bg-brand-background px-6 py-3 font-heading font-semibold text-brand-primary"
               >
                 Instagram
               </a>


### PR DESCRIPTION
## Summary
- style CTA buttons with `.cta-link` utility so they contrast against the hero background in high-contrast mode
- add high-contrast rule that inverts CTA colors and adds a border

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf81662b34832aa489c02d85650bdb