### PR TITLE
fix: serve index for client routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,10 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/((?!.*\\..*).*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- rewrite Vercel routing to always serve index.html for client-side routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfdd60fdfc832a85eac0b643156333