### PR TITLE
feat: share language context across app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,17 +5,20 @@ import Diseases from './pages/Diseases'
 import Articles from './pages/Articles'
 import Article from './pages/Article'
 import Container from './components/Container'
+import { LanguageProvider } from './hooks/useLanguage'
 
 export default function App() {
   return (
-    <Container>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/diseases" element={<Diseases />} />
-        <Route path="/diseases/:slug" element={<Disease />} />
-        <Route path="/artikel" element={<Articles />} />
-        <Route path="/artikel/:slug" element={<Article />} />
-      </Routes>
-    </Container>
+    <LanguageProvider>
+      <Container>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/diseases" element={<Diseases />} />
+          <Route path="/diseases/:slug" element={<Disease />} />
+          <Route path="/artikel" element={<Articles />} />
+          <Route path="/artikel/:slug" element={<Article />} />
+        </Routes>
+      </Container>
+    </LanguageProvider>
   )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,11 +2,10 @@ import { Link } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import clsx from 'clsx'
 import { getLabels, Lang } from '../i18n'
+import { useLanguage } from '../hooks/useLanguage'
 
 export default function Header() {
-  const [lang, setLang] = useState<Lang>(
-    () => (localStorage.getItem('ui:lang') as Lang) || 'id'
-  )
+  const { lang, setLang } = useLanguage()
   const [highContrast, setHighContrast] = useState(
     () => localStorage.getItem('a11y:zmc:contrast') === '1'
   )
@@ -23,10 +22,6 @@ export default function Header() {
   useEffect(() => {
     localStorage.setItem('a11y:zmc:font', largeText ? '1' : '0')
   }, [largeText])
-
-  useEffect(() => {
-    localStorage.setItem('ui:lang', lang)
-  }, [lang])
 
   return (
     <header

--- a/src/hooks/useLanguage.tsx
+++ b/src/hooks/useLanguage.tsx
@@ -1,0 +1,39 @@
+import { ReactNode, createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { Lang } from '../i18n'
+
+type LanguageContextValue = {
+  lang: Lang
+  setLang: (lang: Lang) => void
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined)
+
+function getInitialLanguage(): Lang {
+  if (typeof window === 'undefined') {
+    return 'id'
+  }
+
+  return (window.localStorage.getItem('ui:lang') as Lang) || 'id'
+}
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Lang>(getInitialLanguage)
+
+  useEffect(() => {
+    window.localStorage.setItem('ui:lang', lang)
+  }, [lang])
+
+  const value = useMemo(() => ({ lang, setLang }), [lang])
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext)
+
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider')
+  }
+
+  return context
+}

--- a/src/pages/Home.test.tsx
+++ b/src/pages/Home.test.tsx
@@ -3,12 +3,15 @@ import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 
 import Home from './Home'
+import { LanguageProvider } from '../hooks/useLanguage'
 
 describe('Home page', () => {
   it('has WhatsApp link', () => {
     render(
       <MemoryRouter>
-        <Home />
+        <LanguageProvider>
+          <Home />
+        </LanguageProvider>
       </MemoryRouter>
     )
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import Section from '../components/Section'
 import ArticleCard from '../components/ArticleCard'
 import { articles } from '../data/articles'
-import { getLabels, Lang } from '../i18n'
+import { getLabels } from '../i18n'
+import { useLanguage } from '../hooks/useLanguage'
 
 export default function Home() {
-  const labels = getLabels((localStorage.getItem('ui:lang') as Lang) || 'id')
+  const { lang } = useLanguage()
+  const labels = getLabels(lang)
   const lines = (labels.appDescription || '').split(/\r?\n/).filter(Boolean)
 
   return (


### PR DESCRIPTION
## Summary
- add a language provider that initializes from localStorage and persists updates
- wrap the application tree so header and pages consume the shared language state
- update the home test to render inside the language provider

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d2501fa1fc832ab45c441f8e46fe73