### PR TITLE
Handle empty quiz data

### DIFF
--- a/src/components/Quiz.test.tsx
+++ b/src/components/Quiz.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import Quiz from './Quiz'
+
+describe('Quiz component', () => {
+  it('renders fallback when there are no questions', () => {
+    const onFinish = vi.fn()
+    render(<Quiz questions={[]} onFinish={onFinish} />)
+
+    expect(screen.getByText('Kuis belum tersedia.')).toBeInTheDocument()
+    expect(onFinish).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/Quiz.tsx
+++ b/src/components/Quiz.tsx
@@ -24,8 +24,6 @@ export default function Quiz({ questions, onFinish }: QuizProps) {
     track('quiz_start', { total: questions.length })
   }, [questions.length])
 
-  const q = questions[current]
-
   function selectOption(index: number) {
     const next = [...selected]
     next[current] = index
@@ -46,6 +44,12 @@ export default function Quiz({ questions, onFinish }: QuizProps) {
       onFinish(s)
     }
   }
+
+  if (questions.length === 0) {
+    return <div className="mt-2">Kuis belum tersedia.</div>
+  }
+
+  const q = questions[current]
 
   if (finished) {
     return (

--- a/src/pages/Disease.test.tsx
+++ b/src/pages/Disease.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Disease from './Disease'
+
+const { getDiseaseBySlug: mockedGetDiseaseBySlug } = vi.hoisted(() => ({
+  getDiseaseBySlug: vi.fn(),
+}))
+
+vi.mock('../data/diseases', () => ({
+  getDiseaseBySlug: mockedGetDiseaseBySlug,
+}))
+
+describe('Disease page', () => {
+  beforeEach(() => {
+    mockedGetDiseaseBySlug.mockReset()
+  })
+
+  it('omits quiz tab when quiz array is empty', () => {
+    mockedGetDiseaseBySlug.mockReturnValue({
+      slug: 'test-disease',
+      name: 'Test Disease',
+      summary: 'Summary',
+      wave: 1,
+      quiz: [],
+      sections: {
+        faktorRisiko: ['Risiko 1'],
+      },
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/disease/test-disease']}>
+        <Routes>
+          <Route path="/disease/:slug" element={<Disease />} />
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByText('Kuis')).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/Disease.tsx
+++ b/src/pages/Disease.tsx
@@ -49,7 +49,7 @@ export default function Disease() {
     s?.penanganan && { key: 'penanganan', label: 'Penanganan', content: renderList(s.penanganan) },
     s?.checklist && { key: 'checklist', label: 'Checklist', content: renderList(s.checklist) },
     s?.faq && { key: 'faq', label: 'FAQ', content: renderList(s.faq) },
-    disease.quiz && {
+    Array.isArray(disease.quiz) && disease.quiz.length > 0 && {
       key: 'quiz',
       label: 'Kuis',
       content: (


### PR DESCRIPTION
## Summary
- guard the disease details page from rendering an empty quiz tab
- add a fallback render path in the quiz component when there are no questions
- cover the empty quiz scenario with new unit tests for the quiz component and disease page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d26adbdfd8832a8f0390415a0ae953